### PR TITLE
Tweak oauth logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ let { data} = await client.submissions().get()
 console.log(data)
 ```
 
-> Note in browser, any session cookies will also go up with the request, so you will not have to authenticate here manually
-
+> Note that when the SDK is ran within a browser, cookies will be forwarded with the API requests in the `Cookie` header. When authenticated, the users session token is forwarded within that header
 
 ### Adding a module (for this example, shoes)
 1. Create a new model file in src/Models, `src/Models/Shoe.ts` which implements the `Model` interface

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ let client = new Client({
     baseDomain: "https://api.ctrl-hub.dev",
     clientId: 'insert-client-id-here',
     clientSecret: 'insert-client-secret-here',
-    authUrl: 'https://auth.ctrl-hub.dev/oauth2/token'
+    authDomain: 'https://auth.ctrl-hub.dev' // a request will be sent to https://auth.ctrl-hub.dev/oauth2/token
 });
 
 // Get all submissions for 'org-name-here' organisation

--- a/dist/Client.js
+++ b/dist/Client.js
@@ -18,17 +18,17 @@ export class Client {
         this.config = config;
         this.organisation = "";
         this.hydrator = new Hydrator(this.services);
-        if (config.clientId && config.clientSecret && config.authUrl) {
+        if (config.clientId && config.clientSecret && config.authDomain) {
             this.tokenPromise = this.getToken();
         }
     }
     async getToken() {
-        const url = this.config.authUrl || '';
+        const url = this.config.authDomain || '';
         const params = new URLSearchParams();
         params.append("grant_type", "client_credentials");
         params.append("client_id", this.config.clientId || '');
         params.append("client_secret", this.config.clientSecret || '');
-        const response = await fetch(url, {
+        const response = await fetch(url + '/oauth2/token', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'

--- a/dist/ClientConfig.d.ts
+++ b/dist/ClientConfig.d.ts
@@ -3,13 +3,13 @@ export type ClientConfigInterface = {
     baseDomain: string;
     clientId?: string;
     clientSecret?: string;
-    authUrl?: string;
+    authDomain?: string;
 };
 export declare class ClientConfig {
     organisationId: string;
     baseDomain: string;
     clientId: string;
     clientSecret: string;
-    authUrl: string;
+    authDomain: string;
     constructor(config: ClientConfigInterface);
 }

--- a/dist/ClientConfig.js
+++ b/dist/ClientConfig.js
@@ -3,12 +3,12 @@ export class ClientConfig {
     baseDomain;
     clientId;
     clientSecret;
-    authUrl;
+    authDomain;
     constructor(config) {
         this.organisationId = config.organisationId;
         this.baseDomain = config.baseDomain || 'https://app.ctrl-hub.com';
         this.clientId = config.clientId || '';
         this.clientSecret = config.clientSecret || '';
-        this.authUrl = config.authUrl || '';
+        this.authDomain = config.authDomain || '';
     }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -565,17 +565,17 @@ class Client {
     this.config = config;
     this.organisation = "";
     this.hydrator = new Hydrator(this.services);
-    if (config.clientId && config.clientSecret && config.authUrl) {
+    if (config.clientId && config.clientSecret && config.authDomain) {
       this.tokenPromise = this.getToken();
     }
   }
   async getToken() {
-    const url = this.config.authUrl || "";
+    const url = this.config.authDomain || "";
     const params = new URLSearchParams;
     params.append("grant_type", "client_credentials");
     params.append("client_id", this.config.clientId || "");
     params.append("client_secret", this.config.clientSecret || "");
-    const response = await fetch(url, {
+    const response = await fetch(url + "/oauth2/token", {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded; charset=utf-8"
@@ -669,13 +669,13 @@ class ClientConfig {
   baseDomain;
   clientId;
   clientSecret;
-  authUrl;
+  authDomain;
   constructor(config) {
     this.organisationId = config.organisationId;
     this.baseDomain = config.baseDomain || "https://app.ctrl-hub.com";
     this.clientId = config.clientId || "";
     this.clientSecret = config.clientSecret || "";
-    this.authUrl = config.authUrl || "";
+    this.authDomain = config.authDomain || "";
   }
 }
 export {

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,105 @@
+import { Client } from './src';
+import {FormCategory} from "./src/models/FormCategory";
+import {ClientConfig} from "./dist";
+import {Form} from "./src/models/Form";
+import { RequestOptions } from './dist/utils/RequestOptions';
+import { ServiceAccount } from './src/models/ServiceAccount';
+
+
+// let config = new ClientConfig()
+
+
+
+// let { data } = await client.forms.get({
+//     sort: [{ key: 'name', direction: 'desc' }],
+//     limit: 2,
+//     offset: 2
+// });
+
+// let { data } = await client.forms.get({
+//     sort: [
+//         {
+//             key: 'name',
+//             direction: 'asc'
+//         }
+//     ],
+//     filters: [
+//         {
+//             key: 'categories.id',
+//             value: 'b60e2af5-6a84-0eb0-feaa-84384a94'
+//         }
+//     ]
+// });
+//
+// for(let d: Form of data) {
+//     console.log(d.attributes.name);
+// }
+
+// let serviceAccount = new ServiceAccount();
+// serviceAccount.attributes.name = "test";
+// let resp = client.create(serviceAccount);
+// console.log(resp);
+
+// const getToken = async () => {
+//     const url = "https://auth.ctrl-hub.dev/oauth2/token";
+//
+//     const params = new URLSearchParams();
+//     params.append("grant_type", "client_credentials");
+//     params.append("client_id", clientId);
+//     params.append("client_secret", clientSecret);
+//
+//     const response = await fetch(url, {
+//         method: 'POST',
+//         headers: {
+//             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'
+//         },
+//         body: params.toString()
+//     });
+//
+//     return response.json();
+// }
+
+let client = new Client({
+    organisationId: "ctrl-hub",
+    baseDomain: "https://api.ctrl-hub.dev",
+    clientId: 'd2cb057a-8896-4a48-85a1-60178f133dd9',
+    clientSecret: 'R1NY7Zurgq.zSGCI5UoHxxq4y3',
+    authDomain: 'https://auth.ctrl-hub.dev'
+});
+
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+let resp = await client.submissions().get();
+console.log(resp);
+
+// await fetchSubmissionsRepeatedly(client, 10000, 70000);
+
+async function fetchSubmissionsRepeatedly(client: Client, intervalMs: number, totalDurationMs: number) {
+    const totalIterations = totalDurationMs / intervalMs; // Calculate how many times to run
+
+    for (let i = 0; i < totalIterations; i++) {
+        let resp = await client.submissions().get();
+        console.log('ok: ' + resp.ok);
+        console.log(`Request ${i + 1}, data length: ${resp.data.length}`);
+
+        if (i < totalIterations - 1) {
+            // Wait for the next iteration, except the last one
+            await delay(intervalMs);
+        }
+    }
+}
+
+// let resp = await client.submissions().get()
+// console.log(resp.data.length);
+// await delay(30*1000)
+//
+// resp = await client.submissions().get()
+// console.log(resp.data.length);
+//
+// // Fetch request using POST method
+
+//
+// // Parse the response as JSON
+// const data = await response.json();
+// console.log(data);

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -24,20 +24,20 @@ export class Client {
     this.organisation = "";
     this.hydrator = new Hydrator(this.services);
 
-    if (config.clientId && config.clientSecret && config.authUrl) {
+    if (config.clientId && config.clientSecret && config.authDomain) {
       this.tokenPromise = this.getToken();
     }
   }
 
   async getToken(){
-    const url = this.config.authUrl || '';
+    const url = this.config.authDomain || '';
 
     const params = new URLSearchParams();
     params.append("grant_type", "client_credentials");
     params.append("client_id", this.config.clientId || '');
     params.append("client_secret", this.config.clientSecret || '');
 
-    const response = await fetch(url, {
+    const response = await fetch(url + '/oauth2/token', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8'

--- a/src/ClientConfig.ts
+++ b/src/ClientConfig.ts
@@ -18,6 +18,6 @@ export class ClientConfig {
         this.baseDomain = config.baseDomain || 'https://app.ctrl-hub.com';
         this.clientId = config.clientId || '';
         this.clientSecret = config.clientSecret || '';
-        this.authDomain = config.authDomain || '';
+        this.authDomain = config.authDomain || 'https://auth.ctrl-hub.com';
     }
 }

--- a/src/ClientConfig.ts
+++ b/src/ClientConfig.ts
@@ -3,7 +3,7 @@ export type ClientConfigInterface = {
     baseDomain: string;
     clientId?: string;
     clientSecret?: string;
-    authUrl?: string;
+    authDomain?: string;
 };
 
 export class ClientConfig {
@@ -11,13 +11,13 @@ export class ClientConfig {
     public baseDomain: string;
     public clientId: string;
     public clientSecret: string;
-    public authUrl: string;
+    public authDomain: string;
 
     constructor(config: ClientConfigInterface) {
         this.organisationId = config.organisationId;
         this.baseDomain = config.baseDomain || 'https://app.ctrl-hub.com';
         this.clientId = config.clientId || '';
         this.clientSecret = config.clientSecret || '';
-        this.authUrl = config.authUrl || '';
+        this.authDomain = config.authDomain || '';
     }
 }


### PR DESCRIPTION
Changes `Client` to take `authDomain` rather than `authUrl` - this will have /oauth2/token added to it implicitly when exchanging the token

Usage now:

```
let client = new Client({
    organisationId: "ctrl-hub",
    baseDomain: "https://api.ctrl-hub.dev",
    clientId: 'b34d58aa-3276-4b47-b596-b07cfaf0a7d4',
    clientSecret: 'R1NY7Zurgq.zSGCI5UoHxxq4y2',
    authDomain: 'https://auth.ctrl-hub.dev'
});
```