### PR TITLE
Allow include query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ let options = {
             value: "be780a63-6944-4305-943c-e715e9177371",
         },
     ],
+    include: [
+        "related-model-1", "related-model-2"
+    ]
 } 
 
 let shoesResponse = client.shoes.get();

--- a/dist/index.js
+++ b/dist/index.js
@@ -418,7 +418,7 @@ class BaseService {
     return single;
   }
   findMatchingIncluded(relation, included) {
-    return included.find((inc) => inc.id === relation.id && inc.type === relation.type);
+    return included?.find((inc) => inc.id === relation.id && inc.type === relation.type);
   }
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,6 +4,7 @@ class RequestOptions {
   limit;
   offset;
   filters;
+  include = [];
   constructor(options) {
     if (options.sort) {
       this.sort = options.sort;
@@ -16,6 +17,9 @@ class RequestOptions {
     }
     if (options.filters) {
       this.filters = options.filters;
+    }
+    if (options.include) {
+      this.include = options.include;
     }
   }
   toURLSearchParams() {
@@ -30,6 +34,9 @@ class RequestOptions {
       this.filters.forEach((filter) => {
         params.append(`filter[${filter.key}]`, filter.value);
       });
+    }
+    if (this.include && this.include.length) {
+      params.append("include", this.include.join(","));
     }
     if (this.limit) {
       params.append("limit", this.limit.toString());
@@ -46,7 +53,8 @@ class RequestOptions {
       filters: [],
       limit: parseInt(queryParams.get("limit") || defaults.limit?.toString() || "20"),
       offset: parseInt(queryParams.get("offset") || defaults.offset?.toString() || "0"),
-      sort: defaults.sort || []
+      sort: defaults.sort || [],
+      include: defaults.include || []
     };
     queryParams.forEach((value, key) => {
       if (key.startsWith("filter[") && key.endsWith("]")) {

--- a/dist/services/BaseService.js
+++ b/dist/services/BaseService.js
@@ -66,6 +66,6 @@ export class BaseService {
         return single;
     }
     findMatchingIncluded(relation, included) {
-        return included.find(inc => inc.id === relation.id && inc.type === relation.type);
+        return included?.find(inc => inc.id === relation.id && inc.type === relation.type);
     }
 }

--- a/dist/utils/RequestOptions.d.ts
+++ b/dist/utils/RequestOptions.d.ts
@@ -11,12 +11,14 @@ export type RequestOptionsType = {
     limit?: number;
     offset?: number;
     filters?: Filter[];
+    include: String[];
 };
 export declare class RequestOptions {
     sort?: Sort[];
     limit?: number;
     offset?: number;
     filters?: Filter[];
+    include: String[];
     constructor(options: RequestOptionsType);
     toURLSearchParams(): URLSearchParams;
     static fromUrl(url: string, defaults?: Partial<RequestOptionsType>): RequestOptionsType;

--- a/dist/utils/RequestOptions.js
+++ b/dist/utils/RequestOptions.js
@@ -3,6 +3,7 @@ export class RequestOptions {
     limit;
     offset;
     filters;
+    include = [];
     constructor(options) {
         if (options.sort) {
             this.sort = options.sort;
@@ -15,6 +16,9 @@ export class RequestOptions {
         }
         if (options.filters) {
             this.filters = options.filters;
+        }
+        if (options.include) {
+            this.include = options.include;
         }
     }
     toURLSearchParams() {
@@ -29,6 +33,9 @@ export class RequestOptions {
             this.filters.forEach(filter => {
                 params.append(`filter[${filter.key}]`, filter.value);
             });
+        }
+        if (this.include && this.include.length) {
+            params.append('include', this.include.join(','));
         }
         if (this.limit) {
             params.append('limit', this.limit.toString());
@@ -47,6 +54,7 @@ export class RequestOptions {
             limit: parseInt(queryParams.get('limit') || defaults.limit?.toString() || '20'),
             offset: parseInt(queryParams.get('offset') || defaults.offset?.toString() || '0'),
             sort: defaults.sort || [],
+            include: defaults.include || [],
         };
         // Extract filters from query string
         queryParams.forEach((value, key) => {

--- a/src/services/BaseService.ts
+++ b/src/services/BaseService.ts
@@ -94,6 +94,6 @@ export class BaseService<T> {
     }
 
     findMatchingIncluded(relation: any, included: any[]) {
-        return included.find(inc => inc.id === relation.id && inc.type === relation.type);
+        return included?.find(inc => inc.id === relation.id && inc.type === relation.type);
     }
 }

--- a/src/utils/RequestOptions.ts
+++ b/src/utils/RequestOptions.ts
@@ -13,6 +13,7 @@ export type RequestOptionsType = {
     limit?: number;
     offset?: number;
     filters?: Filter[];
+    include: String[]
 };
 
 export class RequestOptions {
@@ -20,6 +21,7 @@ export class RequestOptions {
     limit?: number;
     offset?: number;
     filters?: Filter[];
+    include: String[] = [];
 
     constructor(options: RequestOptionsType) {
         if (options.sort) {
@@ -33,6 +35,9 @@ export class RequestOptions {
         }
         if (options.filters) {
             this.filters = options.filters
+        }
+        if (options.include) {
+            this.include = options.include
         }
     }
 
@@ -51,6 +56,10 @@ export class RequestOptions {
             this.filters.forEach(filter => {
                 params.append(`filter[${filter.key}]`, filter.value);
             });
+        }
+
+        if (this.include && this.include.length) {
+            params.append('include', this.include.join(','));
         }
 
         if (this.limit) {
@@ -74,6 +83,7 @@ export class RequestOptions {
             limit: parseInt(queryParams.get('limit') || defaults.limit?.toString() || '20'),
             offset: parseInt(queryParams.get('offset') || defaults.offset?.toString() || '0'),
             sort: defaults.sort || [],
+            include: defaults.include || [],
         };
 
         // Extract filters from query string


### PR DESCRIPTION
Allows specifying related models to include e.g.

```
let resp = await api.vehicles().get({
    include: ['model', 'equipment', 'manufacturer'],
});
```

> Note: value must be an array of strings