### PR TITLE
remove statuses from projects

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -885,7 +885,6 @@ class Scheme extends BaseModel {
   name = "";
   code = "";
   description = "";
-  status = "";
   start_date = "";
   end_date = "";
   labels = [];
@@ -901,14 +900,13 @@ class Scheme extends BaseModel {
     this.name = data?.attributes?.name ?? data?.name ?? "";
     this.code = data?.attributes?.code ?? data?.code ?? "";
     this.description = data?.attributes?.description ?? data?.description ?? "";
-    this.status = data?.attributes?.status ?? data?.status ?? "";
     this.start_date = data?.attributes?.start_date ?? data?.start_date ?? "";
     this.end_date = data?.attributes?.end_date ?? data?.end_date ?? "";
     this.labels = data?.attributes?.labels ?? data?.labels ?? [];
   }
   jsonApiMapping() {
     return {
-      attributes: ["name", "code", "description", "status", "start_date", "end_date", "labels"]
+      attributes: ["name", "code", "description", "start_date", "end_date", "labels"]
     };
   }
 }
@@ -919,12 +917,9 @@ class WorkOrder extends BaseModel {
   name = "";
   code = "";
   description = "";
-  status = "";
   start_date = "";
   end_date = "";
   labels = [];
-  uprns = [];
-  usrns = [];
   static relationships = [
     {
       name: "operations",
@@ -937,16 +932,13 @@ class WorkOrder extends BaseModel {
     this.name = data?.attributes?.name ?? data?.name ?? "";
     this.code = data?.attributes?.code ?? data?.code ?? "";
     this.description = data?.attributes?.description ?? data?.description ?? "";
-    this.status = data?.attributes?.status ?? data?.status ?? "";
     this.start_date = data?.attributes?.start_date ?? data?.start_date ?? "";
     this.end_date = data?.attributes?.end_date ?? data?.end_date ?? "";
     this.labels = data?.attributes?.labels ?? data?.labels ?? [];
-    this.uprns = data?.attributes?.uprns ?? data?.uprns ?? [];
-    this.usrns = data?.attributes?.usrns ?? data?.usrns ?? [];
   }
   jsonApiMapping() {
     return {
-      attributes: ["name", "code", "description", "status", "start_date", "end_date", "labels"]
+      attributes: ["name", "code", "description", "start_date", "end_date", "labels"]
     };
   }
 }
@@ -1841,28 +1833,32 @@ class Operation extends BaseModel {
   name = "";
   code = "";
   description = "";
-  status = "";
   start_date = "";
   end_date = "";
   labels = [];
   uprns = [];
   usrns = [];
+  completed = false;
+  aborted = false;
+  cancelled = false;
   static relationships = [];
   constructor(data) {
     super(data);
     this.name = data?.attributes?.name ?? data?.name ?? "";
     this.code = data?.attributes?.code ?? data?.code ?? "";
     this.description = data?.attributes?.description ?? data?.description ?? "";
-    this.status = data?.attributes?.status ?? data?.status ?? "";
     this.start_date = data?.attributes?.start_date ?? data?.start_date ?? "";
     this.end_date = data?.attributes?.end_date ?? data?.end_date ?? "";
     this.labels = data?.attributes?.labels ?? data?.labels ?? [];
     this.uprns = data?.attributes?.uprns ?? data?.uprns ?? [];
     this.usrns = data?.attributes?.usrns ?? data?.usrns ?? [];
+    this.completed = data?.attributes?.completed ?? data?.completed ?? false;
+    this.aborted = data?.attributes?.aborted ?? data?.aborted ?? false;
+    this.cancelled = data?.attributes?.cancelled ?? data?.cancelled ?? false;
   }
   jsonApiMapping() {
     return {
-      attributes: ["name", "code", "description", "status", "start_date", "end_date", "labels"]
+      attributes: ["name", "code", "description", "start_date", "end_date", "labels", "uprns", "usrns", "completed", "aborted", "cancelled"]
     };
   }
 }

--- a/dist/models/Operation.d.ts
+++ b/dist/models/Operation.d.ts
@@ -6,12 +6,14 @@ export declare class Operation extends BaseModel {
     name: string;
     code: string;
     description: string;
-    status: string;
     start_date: string;
     end_date: string;
     labels: Array<Label>;
     uprns: Array<number>;
     usrns: Array<number>;
+    completed: boolean;
+    aborted: boolean;
+    cancelled: boolean;
     static relationships: RelationshipDefinition[];
     constructor(data?: any);
     jsonApiMapping(): {

--- a/dist/models/Operation.js
+++ b/dist/models/Operation.js
@@ -4,28 +4,32 @@ export class Operation extends BaseModel {
     name = '';
     code = '';
     description = '';
-    status = '';
     start_date = '';
     end_date = '';
     labels = [];
     uprns = [];
     usrns = [];
+    completed = false;
+    aborted = false;
+    cancelled = false;
     static relationships = [];
     constructor(data) {
         super(data);
         this.name = data?.attributes?.name ?? data?.name ?? '';
         this.code = data?.attributes?.code ?? data?.code ?? '';
         this.description = data?.attributes?.description ?? data?.description ?? '';
-        this.status = data?.attributes?.status ?? data?.status ?? '';
         this.start_date = data?.attributes?.start_date ?? data?.start_date ?? '';
         this.end_date = data?.attributes?.end_date ?? data?.end_date ?? '';
         this.labels = data?.attributes?.labels ?? data?.labels ?? [];
         this.uprns = data?.attributes?.uprns ?? data?.uprns ?? [];
         this.usrns = data?.attributes?.usrns ?? data?.usrns ?? [];
+        this.completed = data?.attributes?.completed ?? data?.completed ?? false;
+        this.aborted = data?.attributes?.aborted ?? data?.aborted ?? false;
+        this.cancelled = data?.attributes?.cancelled ?? data?.cancelled ?? false;
     }
     jsonApiMapping() {
         return {
-            attributes: ['name', 'code', 'description', 'status', 'start_date', 'end_date', 'labels'],
+            attributes: ['name', 'code', 'description', 'start_date', 'end_date', 'labels', 'uprns', 'usrns', 'completed', 'aborted', 'cancelled'],
         };
     }
 }

--- a/dist/models/Scheme.d.ts
+++ b/dist/models/Scheme.d.ts
@@ -6,7 +6,6 @@ export declare class Scheme extends BaseModel {
     name: string;
     code: string;
     description: string;
-    status: string;
     start_date: string;
     end_date: string;
     labels: Array<Label>;

--- a/dist/models/Scheme.js
+++ b/dist/models/Scheme.js
@@ -4,7 +4,6 @@ export class Scheme extends BaseModel {
     name = '';
     code = '';
     description = '';
-    status = '';
     start_date = '';
     end_date = '';
     labels = [];
@@ -20,14 +19,13 @@ export class Scheme extends BaseModel {
         this.name = data?.attributes?.name ?? data?.name ?? '';
         this.code = data?.attributes?.code ?? data?.code ?? '';
         this.description = data?.attributes?.description ?? data?.description ?? '';
-        this.status = data?.attributes?.status ?? data?.status ?? '';
         this.start_date = data?.attributes?.start_date ?? data?.start_date ?? '';
         this.end_date = data?.attributes?.end_date ?? data?.end_date ?? '';
         this.labels = data?.attributes?.labels ?? data?.labels ?? [];
     }
     jsonApiMapping() {
         return {
-            attributes: ['name', 'code', 'description', 'status', 'start_date', 'end_date', 'labels'],
+            attributes: ['name', 'code', 'description', 'start_date', 'end_date', 'labels'],
         };
     }
 }

--- a/dist/models/WorkOrder.d.ts
+++ b/dist/models/WorkOrder.d.ts
@@ -6,12 +6,9 @@ export declare class WorkOrder extends BaseModel {
     name: string;
     code: string;
     description: string;
-    status: string;
     start_date: string;
     end_date: string;
     labels: Array<Label>;
-    uprns: Array<number>;
-    usrns: Array<number>;
     static relationships: RelationshipDefinition[];
     constructor(data?: any);
     jsonApiMapping(): {

--- a/dist/models/WorkOrder.js
+++ b/dist/models/WorkOrder.js
@@ -4,12 +4,9 @@ export class WorkOrder extends BaseModel {
     name = '';
     code = '';
     description = '';
-    status = '';
     start_date = '';
     end_date = '';
     labels = [];
-    uprns = [];
-    usrns = [];
     static relationships = [
         {
             name: 'operations',
@@ -22,16 +19,13 @@ export class WorkOrder extends BaseModel {
         this.name = data?.attributes?.name ?? data?.name ?? '';
         this.code = data?.attributes?.code ?? data?.code ?? '';
         this.description = data?.attributes?.description ?? data?.description ?? '';
-        this.status = data?.attributes?.status ?? data?.status ?? '';
         this.start_date = data?.attributes?.start_date ?? data?.start_date ?? '';
         this.end_date = data?.attributes?.end_date ?? data?.end_date ?? '';
         this.labels = data?.attributes?.labels ?? data?.labels ?? [];
-        this.uprns = data?.attributes?.uprns ?? data?.uprns ?? [];
-        this.usrns = data?.attributes?.usrns ?? data?.usrns ?? [];
     }
     jsonApiMapping() {
         return {
-            attributes: ['name', 'code', 'description', 'status', 'start_date', 'end_date', 'labels'],
+            attributes: ['name', 'code', 'description', 'start_date', 'end_date', 'labels'],
         };
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/ctrl-hub/sdk.ts"
     },
-    "version": "0.1.108",
+    "version": "0.1.109",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",

--- a/src/models/Operation.ts
+++ b/src/models/Operation.ts
@@ -8,12 +8,14 @@ export class Operation extends BaseModel {
     public name: string = '';
     public code: string = '';
     public description: string = '';
-    public status: string = '';
     public start_date: string = '';
     public end_date: string = '';
     public labels: Array<Label> = [];
     public uprns: Array<number> = [];
     public usrns: Array<number> = [];
+    public completed: boolean = false;
+    public aborted: boolean = false;
+    public cancelled: boolean = false;
 
     static relationships: RelationshipDefinition[] = [];
 
@@ -22,17 +24,19 @@ export class Operation extends BaseModel {
         this.name = data?.attributes?.name ?? data?.name ?? '';
         this.code = data?.attributes?.code ?? data?.code ?? '';
         this.description = data?.attributes?.description ?? data?.description ?? '';
-        this.status = data?.attributes?.status ?? data?.status ?? '';
         this.start_date = data?.attributes?.start_date ?? data?.start_date ?? '';
         this.end_date = data?.attributes?.end_date ?? data?.end_date ?? '';
         this.labels = data?.attributes?.labels ?? data?.labels ?? [];
         this.uprns = data?.attributes?.uprns ?? data?.uprns ?? [];
         this.usrns = data?.attributes?.usrns ?? data?.usrns ?? [];
+        this.completed = data?.attributes?.completed ?? data?.completed ?? false;
+        this.aborted = data?.attributes?.aborted ?? data?.aborted ?? false;
+        this.cancelled = data?.attributes?.cancelled ?? data?.cancelled ?? false;
     }
 
     jsonApiMapping() {
         return {
-            attributes: ['name', 'code', 'description', 'status', 'start_date', 'end_date', 'labels'],
+            attributes: ['name', 'code', 'description', 'start_date', 'end_date', 'labels', 'uprns', 'usrns', 'completed', 'aborted', 'cancelled'],
         };
     }
 }

--- a/src/models/Scheme.ts
+++ b/src/models/Scheme.ts
@@ -8,7 +8,6 @@ export class Scheme extends BaseModel {
     public name: string = '';
     public code: string = '';
     public description: string = '';
-    public status: string = '';
     public start_date: string = '';
     public end_date: string = '';
     public labels: Array<Label> = [];
@@ -26,7 +25,6 @@ export class Scheme extends BaseModel {
         this.name = data?.attributes?.name ?? data?.name ?? '';
         this.code = data?.attributes?.code ?? data?.code ?? '';
         this.description = data?.attributes?.description ?? data?.description ?? '';
-        this.status = data?.attributes?.status ?? data?.status ?? '';
         this.start_date = data?.attributes?.start_date ?? data?.start_date ?? '';
         this.end_date = data?.attributes?.end_date ?? data?.end_date ?? '';
         this.labels = data?.attributes?.labels ?? data?.labels ?? [];
@@ -34,7 +32,7 @@ export class Scheme extends BaseModel {
 
     jsonApiMapping() {
         return {
-            attributes: ['name', 'code', 'description', 'status', 'start_date', 'end_date', 'labels'],
+            attributes: ['name', 'code', 'description', 'start_date', 'end_date', 'labels'],
         };
     }
 }

--- a/src/models/WorkOrder.ts
+++ b/src/models/WorkOrder.ts
@@ -8,12 +8,9 @@ export class WorkOrder extends BaseModel {
     public name: string = '';
     public code: string = '';
     public description: string = '';
-    public status: string = '';
     public start_date: string = '';
     public end_date: string = '';
     public labels: Array<Label> = [];
-    public uprns: Array<number> = [];
-    public usrns: Array<number> = [];
 
     static relationships: RelationshipDefinition[] = [
         {
@@ -28,17 +25,14 @@ export class WorkOrder extends BaseModel {
         this.name = data?.attributes?.name ?? data?.name ?? '';
         this.code = data?.attributes?.code ?? data?.code ?? '';
         this.description = data?.attributes?.description ?? data?.description ?? '';
-        this.status = data?.attributes?.status ?? data?.status ?? '';
         this.start_date = data?.attributes?.start_date ?? data?.start_date ?? '';
         this.end_date = data?.attributes?.end_date ?? data?.end_date ?? '';
         this.labels = data?.attributes?.labels ?? data?.labels ?? [];
-        this.uprns = data?.attributes?.uprns ?? data?.uprns ?? [];
-        this.usrns = data?.attributes?.usrns ?? data?.usrns ?? [];
     }
 
     jsonApiMapping() {
         return {
-            attributes: ['name', 'code', 'description', 'status', 'start_date', 'end_date', 'labels'],
+            attributes: ['name', 'code', 'description', 'start_date', 'end_date', 'labels'],
         };
     }
 }


### PR DESCRIPTION
Status is inferred by the level of completeness of Operations. Operations have bools for complete, cancelled and aborted.

To cater for this we need to remove status as the completeness will come from the API responses meta