### PR TITLE
fix hydration issue

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1244,6 +1244,8 @@ class Hydrator {
     return this.modelMap;
   };
   hydrateResponse(data, included) {
+    if (!data)
+      return data;
     return Array.isArray(data) ? this.hydrateArray(data, included) : this.hydrateSingle(data, included);
   }
   hydrateArray(items, included) {

--- a/dist/utils/Hydrator.js
+++ b/dist/utils/Hydrator.js
@@ -73,6 +73,8 @@ export class Hydrator {
         return this.modelMap;
     };
     hydrateResponse(data, included) {
+        if (!data)
+            return data;
         return Array.isArray(data) ? this.hydrateArray(data, included) : this.hydrateSingle(data, included);
     }
     hydrateArray(items, included) {

--- a/src/utils/Hydrator.ts
+++ b/src/utils/Hydrator.ts
@@ -79,6 +79,7 @@ export class Hydrator {
     };
 
     hydrateResponse<T extends Model>(data: JsonData | JsonData[], included: any[]): T | T[] {
+        if (!data) return data;
         return Array.isArray(data) ? this.hydrateArray<T>(data, included) : this.hydrateSingle<T>(data, included);
     }
 


### PR DESCRIPTION
Currently the SDK only checks if `data` is an array, if not it will try to hydrate a single model. However, if the API returns a 404 `data` will be null and therefore the SDK should not attempt to hydrate anything as the `data.type` will not exist.