### PR TITLE
Add new fields to permission model

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -379,11 +379,19 @@ class Group extends BaseModel {
 // src/models/Permission.ts
 class Permission extends BaseModel {
   type = "permissions";
+  name = "";
   description = "";
+  category = "";
+  component = "";
+  verb = "";
   static relationships = [];
   constructor(data) {
     super(data);
-    this.description = data?.attributes?.description ?? "";
+    this.name = data?.attributes?.name ?? data?.name ?? "";
+    this.description = data?.attributes?.description ?? data?.description ?? "";
+    this.category = data?.attributes?.category ?? data?.category ?? "";
+    this.component = data?.attributes?.component ?? data?.component ?? "";
+    this.verb = data?.attributes?.verb ?? data?.verb;
   }
 }
 

--- a/dist/models/Permission.d.ts
+++ b/dist/models/Permission.d.ts
@@ -2,7 +2,11 @@ import type { RelationshipDefinition } from '../types/RelationshipDefinition';
 import { BaseModel } from './BaseModel';
 export declare class Permission extends BaseModel {
     type: string;
+    name: string;
     description: string;
+    category: string;
+    component: string;
+    verb: string;
     static relationships: RelationshipDefinition[];
     constructor(data?: any);
 }

--- a/dist/models/Permission.js
+++ b/dist/models/Permission.js
@@ -1,10 +1,18 @@
 import { BaseModel } from './BaseModel';
 export class Permission extends BaseModel {
     type = 'permissions';
+    name = '';
     description = '';
+    category = '';
+    component = '';
+    verb = '';
     static relationships = [];
     constructor(data) {
         super(data);
-        this.description = data?.attributes?.description ?? '';
+        this.name = data?.attributes?.name ?? data?.name ?? '';
+        this.description = data?.attributes?.description ?? data?.description ?? '';
+        this.category = data?.attributes?.category ?? data?.category ?? '';
+        this.component = data?.attributes?.component ?? data?.component ?? '';
+        this.verb = data?.attributes?.verb ?? data?.verb;
     }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/ctrl-hub/sdk.ts"
     },
-    "version": "0.1.130",
+    "version": "0.1.131",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",

--- a/src/models/Permission.ts
+++ b/src/models/Permission.ts
@@ -4,13 +4,25 @@ import { BaseModel } from '@models/BaseModel';
 export class Permission extends BaseModel {
     public type: string = 'permissions';
 
+    public name: string = '';
+
     public description: string = '';
+
+    public category: string = '';
+
+    public component: string = '';
+
+    public verb: string = '';
 
     static relationships: RelationshipDefinition[] = [];
 
     constructor(data?: any) {
         super(data);
-        this.description = data?.attributes?.description ?? '';
+        this.name = data?.attributes?.name ?? data?.name ?? '';
+        this.description = data?.attributes?.description ?? data?.description ?? '';
+        this.category = data?.attributes?.category ?? data?.category ?? '';
+        this.component = data?.attributes?.component ?? data?.component ?? '';
+        this.verb = data?.attributes?.verb ?? data?.verb
     }
 
 }


### PR DESCRIPTION
Struct for "permission" has been changed in svc.iam to:

```
type Permission struct {
	ID          string `bson:"id" json:"id" jsonapi:"primary,permissions"`
	Name        string `bson:"name" json:"name" jsonapi:"attribute"`
	Category    string `bson:"category" json:"category" jsonapi:"attribute"`
	Component   string `bson:"component" json:"component" jsonapi:"attribute"`
	Verb        string `bson:"verb" json:"verb" jsonapi:"attribute"`
	Description string `bson:"description" json:"description" jsonapi:"attribute"`
}
```

this reflects that change in the sdk