### PR TITLE
Fix sort direction ts

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1331,10 +1331,15 @@ class RequestBuilder {
     return this;
   }
   withSort(sort) {
-    this.requestOptions.sort = sort.map((sortOption) => ({
-      key: sortOption.key,
-      direction: sortOption.direction || "asc"
-    }));
+    this.requestOptions.sort = sort.map((sortOption) => {
+      if (sortOption.direction && sortOption.direction !== "asc" && sortOption.direction !== "desc") {
+        throw new Error(`Sort direction must be either 'asc' or 'desc', got: ${sortOption.direction}`);
+      }
+      return {
+        key: sortOption.key,
+        direction: sortOption.direction
+      };
+    });
     return this;
   }
   withFilters(filters) {

--- a/dist/utils/RequestBuilder.d.ts
+++ b/dist/utils/RequestBuilder.d.ts
@@ -1,11 +1,11 @@
 import { RequestOptions } from "../utils/RequestOptions";
-import type { RequestOptionsType } from "../utils/RequestOptions";
+import type { RequestOptionsType, SortDirection } from "../utils/RequestOptions";
 export declare class RequestBuilder {
     protected requestOptions: RequestOptionsType;
     withIncludes(includes: string[]): this;
     withSort(sort: Array<{
         key: string;
-        direction?: 'asc' | 'desc';
+        direction?: SortDirection;
     }>): this;
     withFilters(filters: Array<{
         key: string;

--- a/dist/utils/RequestBuilder.js
+++ b/dist/utils/RequestBuilder.js
@@ -6,10 +6,15 @@ export class RequestBuilder {
         return this;
     }
     withSort(sort) {
-        this.requestOptions.sort = sort.map(sortOption => ({
-            key: sortOption.key,
-            direction: sortOption.direction || 'asc'
-        }));
+        this.requestOptions.sort = sort.map(sortOption => {
+            if (sortOption.direction && sortOption.direction !== 'asc' && sortOption.direction !== 'desc') {
+                throw new Error(`Sort direction must be either 'asc' or 'desc', got: ${sortOption.direction}`);
+            }
+            return {
+                key: sortOption.key,
+                direction: sortOption.direction
+            };
+        });
         return this;
     }
     withFilters(filters) {

--- a/dist/utils/RequestOptions.d.ts
+++ b/dist/utils/RequestOptions.d.ts
@@ -1,6 +1,7 @@
+export type SortDirection = 'asc' | 'desc' | string;
 type Sort = {
     key: string;
-    direction?: 'asc' | 'desc';
+    direction?: SortDirection;
 };
 type Filter = {
     key: string;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/ctrl-hub/sdk.ts"
     },
-    "version": "0.1.134",
+    "version": "0.1.135",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "type": "module",

--- a/src/utils/RequestBuilder.ts
+++ b/src/utils/RequestBuilder.ts
@@ -1,5 +1,5 @@
 import {RequestOptions} from "../utils/RequestOptions";
-import type {RequestOptionsType} from "../utils/RequestOptions";
+import type {RequestOptionsType, SortDirection} from "../utils/RequestOptions";
 
 export class RequestBuilder {
     protected requestOptions: RequestOptionsType = {};
@@ -9,11 +9,18 @@ export class RequestBuilder {
         return this;
     }
 
-    withSort(sort: Array<{ key: string, direction?: 'asc' | 'desc' }>): this {
-        this.requestOptions.sort = sort.map(sortOption => ({
-            key: sortOption.key,
-            direction: sortOption.direction || 'asc'
-        }));
+    withSort(sort: Array<{ key: string, direction?: SortDirection }>): this {
+        this.requestOptions.sort = sort.map(sortOption => {
+
+            if (sortOption.direction && sortOption.direction !== 'asc' && sortOption.direction !== 'desc') {
+                throw new Error(`Sort direction must be either 'asc' or 'desc', got: ${sortOption.direction}`);
+            }
+
+            return {
+                key: sortOption.key,
+                direction: sortOption.direction
+            };
+        });
         return this;
     }
 

--- a/src/utils/RequestOptions.ts
+++ b/src/utils/RequestOptions.ts
@@ -1,6 +1,8 @@
+export type SortDirection = 'asc' | 'desc' | string;
+
 type Sort = {
     key: string;
-    direction?: 'asc' | 'desc';
+    direction?: SortDirection;
 };
 
 type Filter = {


### PR DESCRIPTION
Before this fix we had to do something like this:

```
const query = {
    sort: [
        {
            key: 'profile.personal.last_name',
            direction: 'asc' as 'asc',
        },
    ],
};

const membersResponse = await api.organisationMembers().get(query);
```

to keep ts happy

but now we do not have to do the extra `as 'asc'` 